### PR TITLE
docs(HRKA-1899): add note regarding URL encoding in header for user name

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,12 +219,12 @@ Um gegenüber dem HCP grösstmögliche Transparenz über die Verwendung der Date
 
 Kontext-Typ und Rollen werden als Teil des Onboardings zusammen mit Heureka definiert und API-seitig validiert.
 
-| Header                       | Beschreibung                                                                                 | Beispiel                              |
-|------------------------------|----------------------------------------------------------------------------------------------|---------------------------------------|
-| X-HEUREKA-RequestContextId   | UUID v4                                                                                      | 000000000-1111-2222-3333-555555555555 |
-| X-HEUREKA-RequestContextType | Beschreibt den fachlichen Kontext in dem der Zugriff stattfindet                             | MEDICATION_CHECK                      |
-| X-HEUREKA-UserRole           | Rolle die beschreibt, wer den Zugriff tätigt (oder SYSTEM für technische Zugriffe ohne User) | PRACTICE                              |
-| X-HEUREKA-UserName           | Name oder Bezeichnung (oder leer für SYSTEM Zugriffe)                                        | Dr. Müller                            | 
+| Header                       | Beschreibung                                                                                    | Beispiel                                          |
+|------------------------------|-------------------------------------------------------------------------------------------------|---------------------------------------            |
+| X-HEUREKA-RequestContextId   | UUID v4                                                                                         | 000000000-1111-2222-3333-555555555555             |
+| X-HEUREKA-RequestContextType | Beschreibt den fachlichen Kontext in dem der Zugriff stattfindet                                | MEDICATION_CHECK                                  |
+| X-HEUREKA-UserRole           | Rolle die beschreibt, wer den Zugriff tätigt (oder SYSTEM für technische Zugriffe ohne User)    | PRACTICE                                          |
+| X-HEUREKA-UserName           | Name oder Bezeichnung (oder leer für SYSTEM Zugriffe). Spezialzeichen als UTF-8 URL-encodieren. | `Dr. M%C3%BCller` (vor URL-Encoding: `Dr. Müller` | 
 
 
 #### Beispiel
@@ -238,7 +238,7 @@ GET /Patient?search...
 X-HEUREKA-RequestContextId: 000000000-1111-2222-3333-555555555555
 X-HEUREKA-RequestContextType: MEDICATION_CHECK
 X-HEUREKA-UserRole: PRACTICE
-X-HEUREKA-UserName: Dr. Müller
+X-HEUREKA-UserName: Dr. M%C3%BCller
 ```
 
 ```bash
@@ -246,7 +246,7 @@ GET /Medication?subject=PATIENT_ID
 X-HEUREKA-RequestContextId: 000000000-1111-2222-3333-555555555555
 X-HEUREKA-RequestContextType: MEDICATION_CHECK
 X-HEUREKA-UserRole: PRACTICE
-X-HEUREKA-UserName: Dr. Müller
+X-HEUREKA-UserName: Dr. M%C3%BCller
 ```
 
 ## Webhooks (Preview)


### PR DESCRIPTION
Header values officially only support ASCII characters, therefore an alternative way should be provided to supply special characters like umlauts. While sending the UTF-8 characters _might_ work in some cases, it is guaranteed to work when URL encoded.